### PR TITLE
fix: ignore database data folder from versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Database data
+data


### PR DESCRIPTION
## Description
This PR fixes a missing `.gitignore` rule to exlcude the local Postgres `data/`folder from version control.

## Main changes
- Added `data/` to `.gitignore`
-
## Motivation
The folder was mistakenly committed and merged in the initial setup PR. 