### PR TITLE
feat: frontend auth

### DIFF
--- a/frontend/src/app/(private)/dashboard/page.tsx
+++ b/frontend/src/app/(private)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+export default function Dashboard() {
+    return (
+        <h1>Dashboard</h1>
+    )
+}

--- a/frontend/src/app/(private)/layout.tsx
+++ b/frontend/src/app/(private)/layout.tsx
@@ -1,0 +1,11 @@
+import { SignedIn } from "@clerk/nextjs";
+
+export default function PrivateLayout({ children }: Readonly<{
+    children: React.ReactNode;
+  }>) {
+    return (
+        <SignedIn>
+            {children}
+        </SignedIn>
+    )
+}

--- a/frontend/src/app/(public)/layout.tsx
+++ b/frontend/src/app/(public)/layout.tsx
@@ -1,9 +1,26 @@
+'use client'
+
+import { SignedOut, useAuth } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
 export default function PublicLayout({ children }: Readonly<{
     children: React.ReactNode;
   }>) {
+    const { isSignedIn } = useAuth()
+    const router = useRouter()
+
+    useEffect(() => {
+        if (isSignedIn) {
+            router.replace('/dashboard')
+        }
+    }, [isSignedIn])
+
     return (
-        <div className="flex items-center justify-center h-[100vh]">
-            {children}
-        </div>
+        <SignedOut>
+            <div className="flex items-center justify-center h-[100vh]">
+                {children}
+            </div>
+        </SignedOut>
     )
 }

--- a/frontend/src/app/(public)/login/[[...rest]]/page.tsx
+++ b/frontend/src/app/(public)/login/[[...rest]]/page.tsx
@@ -1,0 +1,7 @@
+import { SignIn } from '@clerk/nextjs'
+
+export default function Login() {
+    return (
+        <SignIn />
+    )
+}

--- a/frontend/src/app/(public)/signup/[[...rest]]/page.tsx
+++ b/frontend/src/app/(public)/signup/[[...rest]]/page.tsx
@@ -1,0 +1,7 @@
+import { SignUp } from '@clerk/nextjs'
+
+export default function Signup() {
+    return (
+        <SignUp />
+    )
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,9 +1,9 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
+const isPublicRoute = createRouteMatcher(['/login(.*)', '/signup(.*)'])
 
 export default clerkMiddleware(async (auth, req) => {
-  if (isProtectedRoute(req)) await auth.protect()
+  if (!isPublicRoute(req)) await auth.protect()
 })
 
 export const config = {


### PR DESCRIPTION
## Description 

This PR adds complete authentication on frontend pages with Clerk.

## Main changes

- Created `/login` and `/signup` pages
- Updated `middleware.ts` to protect all routes except `/login` and `/signup`
- Added access control on private routes 

## Motivation

Private routes protection and access control on frontend.

## How to test

1. Try access `/dashboard` directly, if not signed in will redirect to `/login`
2. Sign up on `/signup`
3. Authenticate on `/login` 

## Related Issues

Closes #9 