### PR TITLE
feat: add vehicles page

### DIFF
--- a/frontend/src/app/(private)/components/sidebar.tsx
+++ b/frontend/src/app/(private)/components/sidebar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChartLine, Package, UsersThree } from "@phosphor-icons/react";
+import { ChartLine, Package, Truck, UsersThree } from "@phosphor-icons/react";
 import Link from "next/link";
 
 export default function Sidebar() {
@@ -30,6 +30,14 @@ export default function Sidebar() {
                 >
                     <UsersThree size={20} />
                     Drivers
+                </Link>
+                <Link
+                    className="flex gap-3 items-center px-[1.875rem] py-[0.875rem] rounded-lg hover:bg-gray-600 transition-all duration-200" 
+                    href='/vehicles'
+                    title="Vehicles"
+                >
+                    <Truck size={20} />
+                    Vehicles
                 </Link>
             </nav>
         </aside>

--- a/frontend/src/app/(private)/vehicles/new/page.tsx
+++ b/frontend/src/app/(private)/vehicles/new/page.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState } from "react";
+
+export default function Page() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selected, setSelected] = useState(`Select the vehicle type`);
+
+    function handleOpenClick(event: React.MouseEvent<HTMLButtonElement>) {
+        event.preventDefault();
+        setIsOpen(!isOpen);
+    }
+
+    return (
+        <div className="w-[50%] pr-[2rem]">
+            <h1 className="font-[600] text-[1.25rem]">Add Vehicle</h1>
+            <form className="flex flex-col w-[60%] mt-[1rem] mb-[1rem]">
+                <label className="mb-[0.5rem]">Plate:</label>
+                <input 
+                    type="text"
+                    className="border border-gray-400 rounded-lg px-[0.875rem] py-[0.25rem] focus:outline-none focus:ring-1 focus:ring-gray-400 transition-all duration-200"
+                    placeholder="Enter vehicle plate"
+                    maxLength={8}
+                />
+                <label className="mb-[0.5rem] mt-[1rem]">Model:</label>
+                <input 
+                    type="text"
+                    className="border border-gray-400 rounded-lg px-[0.875rem] py-[0.25rem] focus:outline-none focus:ring-1 focus:ring-gray-400 transition-all duration-200"
+                    placeholder="Enter the vehicle model"
+                />
+                <label className="mb-[0.5rem] mt-[1rem]">Year:</label>
+                <input 
+                    type="text"
+                    className="border border-gray-400 rounded-lg px-[0.875rem] py-[0.25rem] focus:outline-none focus:ring-1 focus:ring-gray-400 transition-all duration-200"
+                    placeholder="Enter the vehicle year"
+                    maxLength={4}
+                />
+
+                <label className="mb-[0.5rem] mt-[1rem]">Type:</label>
+                <div className="relative w-64 w-full">
+                    <button
+                        onClick={handleOpenClick}
+                        className="w-full py-[0.25rem] text-green-700 border border-gray-300 rounded-md shadow-sm focus:border-green-700 cursor-pointer"
+                    >
+                        {selected}
+                    </button>
+
+                    { isOpen && (
+                        <ul className="absolute w-full bg-gray-700 border border-gray-300 rounded-md mt-1 shadow-lg">
+                            <li
+                                onClick={() => {
+                                    setSelected('Car');
+                                    setIsOpen(false);
+                                }}
+                                className="py-[0.25rem] px-[1rem] hover:bg-gray-200 text-green-700 cursor-pointer transition-colors"
+                            >Car</li>
+                            <li
+                                onClick={() => {
+                                    setSelected('Truck');
+                                    setIsOpen(false);
+                                }}
+                                className="py-[0.25rem] px-[1rem] hover:bg-gray-200 text-green-700 cursor-pointer transition-colors"
+                            >Truck</li>
+                            <li
+                                onClick={() => {
+                                    setSelected('Van');
+                                    setIsOpen(false);
+                                }}
+                                className="py-[0.25rem] px-[1rem] hover:bg-gray-200 text-green-700 cursor-pointer transition-colors"
+                            >Van</li>
+                        </ul>
+                        )
+                    }    
+                </div>                
+            </form>
+            <button className="p-[0.5rem] bg-blue-500 hover:bg-blue-400 mt-[1rem] rounded-lg font-[500] cursor-pointer w-[8rem] transition-all duration-400">
+                Add
+            </button>
+        </div>
+    )
+}

--- a/frontend/src/app/(private)/vehicles/page.tsx
+++ b/frontend/src/app/(private)/vehicles/page.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { Truck, Van } from "@phosphor-icons/react";
+import Link from "next/link";
+
+const vehicles = [
+    {
+        id: '1',
+        model: "Volvo FH16",
+        type: "Truck",
+        plate: "ABC1234",
+        year: 2019
+    },
+    {
+        id: '2',
+        model: "Ford Transit",
+        type: "Van",
+        plate: "XYZ9878",
+        year: 2021
+    },
+    {
+        id: '3',
+        model: "Scania R-series",
+        type: "Truck",
+        plate: "NYC8765H",
+        year: 2016
+    },
+    {
+        id: '4',
+        model: "Renault Master",
+        type: "Van",
+        plate: "XYZ9A99",
+        year: 2017
+    },
+]
+
+export default function Page() {
+    return (
+        <div className="flex flex-col w-full items-center">
+            <div className="flex justify-between w-full">
+                <h1 className="font-[600] text-[1.25rem]">Vehicles</h1>
+                <div>
+                    <Link href='vehicles/new' className="bg-blue-500 px-[2rem] py-[0.25rem] rounded-lg cursor-pointer hover:bg-blue-400 transition-all duration-400">
+                        New vehicle
+                    </Link>
+                </div>
+            </div>
+            <div className="overflow-auto mt-[1rem] w-full">
+                <table className="w-full border-collpse leading-6 mt-[1rem]">
+                    <thead className="bg-gray-500 border-b-2 border-gray-600">
+                        <tr className="rounded-t-lg font-[400]">
+                            <th className="p-2 text-left leaging-6 first:pl-6 first:rounded-tl-[8px]">
+                                Plate
+                            </th>
+                            <th className="p-2 text-left leaging-6">
+                                Type
+                            </th>
+                            <th className="p-2 text-left leaging-6">
+                                Model
+                            </th>
+                            <th className="p-2 text-left leaging-6 last:rounded-tr-[8px]">
+                                Year
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {vehicles.map((row) => (
+                            <tr className="border-b border-gray-500 first:pl-6 last:pr-6" key={row.id}>
+                                <td className="p-2 first:pl-6 last:pr-6 w-[20%]">{row.plate}</td>
+                                <td className="p-2">
+                                    <div className="flex items-center gap-3">
+                                        {row.type === 'Truck' ? (
+                                            <>
+                                                Truck
+                                                <Truck size={18} />
+                                            </>
+                                        ) : (
+                                            <>
+                                                Van
+                                                <Van size={18} />
+                                            </>
+                                        )
+                                        }
+                                    </div>
+                                </td>
+                                <td className="p-2">{row.model}</td>
+                                <td className="p-2">{row.year}</td>
+                            </tr>
+                        ))}
+                    </tbody>    
+                </table>           
+            </div>
+            <button className="p-[0.5rem] mt-[1rem] text-gray-200 font-[500] cursor-pointer w-[8rem] hover:text-gray-100 transition-all duration-400">
+                Show More
+            </button>
+        </div>
+    )
+}


### PR DESCRIPTION
## Description

This PR provides the vehicles section with a paginated list and a form to add new vehicles.

## Main changes

- Added `/vehicles` page displaying a paginated list of vehicles and a "New vehicle" button
- Created `/vehicles/new` page with a form to register a new vehicle and select a type

## Motivation

These changes enable users to view the list of registered vehicles and register new vehicles in the application.

## How to test

1. Go to `/vehicles` — you should see a paginated list of vehicles
2. Click the **"New vehicle"** button — it should redirect to `/vehicles/new`
3. On `/vehicles/new`, verify that the form is displayed and includes a vehicle type selection field

## Related issues

Closes #16 