### PR TITLE
feat: add deliveries page

### DIFF
--- a/frontend/src/app/(private)/deliveries/new/page.tsx
+++ b/frontend/src/app/(private)/deliveries/new/page.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { CaretDown, Plus } from "@phosphor-icons/react";
+import { useState } from "react";
+
+const drivers = [
+    {
+        id: '1',
+        name: "John Doe",
+        license: "123",
+    },
+    {
+        id: '2',
+        name: "Bob Johnson",
+        license: "456",
+    },
+]
+
+export default function Page() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selected, setSelected] = useState(`Select the driver`);
+
+    function handleOpenClick(event: React.MouseEvent<HTMLButtonElement>) {
+        event.preventDefault();
+        setIsOpen(!isOpen);
+    }
+
+    return (
+        <div className="w-[50%] pr-[2rem]">
+            <h1 className="font-[600] text-[1.25rem]">Add Delivery</h1>
+            <form className="flex flex-col w-[60%] mt-[1rem] mb-[2rem]">
+                <label className="mb-[0.5rem]">From:</label>
+                <input 
+                    type="text"
+                    className="border border-gray-400 rounded-lg px-[0.875rem] py-[0.25rem] focus:outline-none focus:ring-1 focus:ring-gray-400 transition-all duration-200"
+                    placeholder="Enter delivery origin"
+                />
+                <label className="mb-[0.5rem] mt-[1rem]">To:</label>
+                <input 
+                    type="text"
+                    className="border border-gray-400 rounded-lg px-[0.875rem] py-[0.25rem] focus:outline-none focus:ring-1 focus:ring-gray-400 transition-all duration-200"
+                    placeholder="Enter delivery destiny"
+                />
+
+                <label className="mb-[0.5rem] mt-[1rem]">Driver:</label>
+                <div className="relative w-64 w-full">
+                    <button
+                        onClick={handleOpenClick}
+                        className="flex justify-between items-center px-[1rem] w-full py-[0.25rem] text-gray-100 border border-gray-400 rounded-md shadow-sm focus:border-green-700 cursor-pointer"
+                    >
+                        {selected}
+                        <CaretDown size={16} />
+                    </button>
+
+                    { isOpen && (
+                        <ul className="absolute w-full bg-gray-700 border border-gray-300 rounded-md mt-1 shadow-lg">
+                            {drivers.map((driver, index) => (
+                            <li
+                                key={index}
+                                onClick={() => {
+                                    setSelected(driver.name);
+                                    setIsOpen(false);
+                                }}
+                                className="py-[0.25rem] px-[1rem] rounded-lg hover:bg-gray-600 text-gray-100 cursor-pointer transition-colors"
+                            >
+                                {driver.name}
+                            </li>
+                            ))}
+                        </ul>
+                        )
+                    }    
+                </div>                
+            </form>
+            <button className="flex items-center justify-center gap-2 p-[0.5rem] bg-blue-500 hover:bg-blue-400 mt-[1rem] rounded-lg font-[500] cursor-pointer w-[8rem] transition-all duration-400">
+                <Plus size={18} />
+                Add
+            </button>
+        </div>
+    )
+}

--- a/frontend/src/app/(private)/deliveries/page.tsx
+++ b/frontend/src/app/(private)/deliveries/page.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { CarProfile, Check, Plus, Spinner, X } from "@phosphor-icons/react";
+import Link from "next/link";
+
+enum DeliveryStatus {
+    PENDING = 'Pending',
+    IN_TRANSIT = 'In transit',
+    DELIVERED = 'Delivered',
+    ISSUES = 'Issues'
+}
+
+const deliveries = [
+    {
+        id: '1',
+        from: "New York (NY)",
+        to: "Los Angeles (CA)",
+        status: DeliveryStatus.IN_TRANSIT,
+    },
+    {
+        id: '2',
+        from: "San Francisco (CA)",
+        to: "Seattle (WA)",
+        status: DeliveryStatus.DELIVERED,
+    },
+    {
+        id: '3',
+        from: "Boston (MA)",
+        to: "Atlanta (GA)",
+        status: DeliveryStatus.ISSUES,
+    },
+    {
+        id: '4',
+        from: "Dallas (TX)",
+        to: "Denver (CO)",
+        status: DeliveryStatus.PENDING,
+    },
+]
+
+export default function Page() {
+    return (
+        <div className="flex flex-col w-full items-center">
+            <div className="flex justify-between w-full">
+                <h1 className="font-[600] text-[1.25rem]">Deliveries</h1>
+                <div>
+                    <Link href='deliveries/new' className="flex items-center gap-3 bg-blue-500 px-[2rem] py-[0.25rem] rounded-lg cursor-pointer hover:bg-blue-400 transition-all duration-400">
+                        <Plus size={18} />
+                        New delivery
+                    </Link>
+                </div>
+            </div>
+            <div className="overflow-auto mt-[1rem] w-full">
+                <table className="w-full border-collpse leading-6 mt-[1rem]">
+                    <thead className="bg-gray-500 border-b-2 border-gray-600">
+                        <tr className="rounded-t-lg font-[400]">
+                            <th className="p-2 text-left leaging-6 first:pl-6 first:rounded-tl-[8px]">
+                                ID
+                            </th>
+                            <th className="p-2 text-left leaging-6">
+                                From
+                            </th>
+                            <th className="p-2 text-left leaging-6">
+                                To
+                            </th>
+                            <th className="p-2 text-left leaging-6 last:rounded-tr-[8px]">
+                                Status
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {deliveries.map((row) => (
+                            <tr className="border-b border-gray-500 first:pl-6 last:pr-6" key={row.id}>
+                                <td className="p-2 first:pl-6 last:pr-6 w-[20%]">{row.id}</td>
+                                <td className="p-2">{row.from}</td>
+                                <td className="p-2">{row.to}</td>
+                                <td className="p-2">
+                                    {(() => {
+                                        switch (row.status) {
+                                            case 'Pending':
+                                                return (
+                                                    <div className="flex justify-center items-center gap-3 rounded-lg bg-yellow-500 text-gray-700">
+                                                        <Spinner size={18} />
+                                                        Pending
+                                                    </div>
+                                                )
+                                            case 'In transit':
+                                                return (
+                                                    <div className="flex justify-center items-center gap-3 rounded-lg bg-blue-400 text-gray-700">
+                                                        <CarProfile size={18} />
+                                                        In transit
+                                                    </div>
+                                                )
+                                            case 'Delivered':
+                                                return (
+                                                    <div className="flex justify-center items-center gap-3 rounded-lg bg-green-500 text-gray-700">
+                                                        <Check size={18} />
+                                                        Delivered
+                                                    </div>
+                                                )
+                                            case 'Issues':
+                                                return (
+                                                    <div className="flex justify-center items-center gap-3 rounded-lg bg-red-500 text-gray-700">
+                                                        <X size={18} />
+                                                        Issues
+                                                    </div>
+                                                )
+                                            default: 
+                                            return null 
+                                        }
+                                    })()}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>    
+                </table>           
+            </div>
+            <button className="p-[0.5rem] mt-[1rem] text-gray-200 font-[500] cursor-pointer w-[8rem] hover:text-gray-100 transition-all duration-400">
+                Show More
+            </button>
+        </div>
+    )
+}


### PR DESCRIPTION
## Description

This PR provides the deliveries section with a paginated list and a form to add new deliveries.

## Main changes

- Added `/deliveries` page displaying a paginated list of deliveries and a "New Delivery" button
- Created `/deliveries/new` page with a form to add a new delivery and select the driver

## Motivation

These changes enable users to view the list of all deliveries with status and add new deliveries in the application.

## How to test

1. Go to `/deliveries` — you should see a paginated list of deliveries
2. Click the **"New deliveries"** button — it should redirect to `/deliveries/new`
3. On `/deliveries/new`, verify that the form is displayed and includes a driver selection field

## Related issues

Closes #18 