### PR TITLE
feat: add delivery details page

### DIFF
--- a/frontend/src/app/(private)/dashboard/page.tsx
+++ b/frontend/src/app/(private)/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { CarProfile, Check, Plus, Spinner, X } from "@phosphor-icons/react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 enum DeliveryStatus {
     PENDING = 'Pending',
@@ -79,6 +80,12 @@ export default function Page() {
     const deliveredDeliveries = deliveries.filter(delivery => delivery.status === DeliveryStatus.DELIVERED)
     const issuesDeliveries = deliveries.filter(delivery => delivery.status === DeliveryStatus.ISSUES)
 
+    const router = useRouter()
+
+    function handleRowClick(deliveryId: string) {
+        router.push(`/deliveries/${deliveryId}`)
+    }
+
     return (
         <div className="flex flex-col w-full items-center">
             <div className="flex justify-between w-full">
@@ -136,7 +143,11 @@ export default function Page() {
                     </thead>
                     <tbody>
                         {deliveries.map((row) => (
-                            <tr className="border-b border-gray-500 first:pl-6 last:pr-6" key={row.id}>
+                            <tr 
+                                className="border-b border-gray-500 first:pl-6 last:pr-6 cursor-pointer hover:bg-gray-500 transition-all duration-300" 
+                                key={row.id}
+                                onClick={ () => handleRowClick(row.id)}
+                            >
                                 <td className="p-2 first:pl-6 last:pr-6 w-[20%]">{row.id}</td>
                                 <td className="p-2">{row.from}</td>
                                 <td className="p-2">{row.to}</td>

--- a/frontend/src/app/(private)/deliveries/[id]/components/dropdown.tsx
+++ b/frontend/src/app/(private)/deliveries/[id]/components/dropdown.tsx
@@ -1,0 +1,114 @@
+import { CaretDown, CarProfile, Check, Spinner, X } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+
+enum DeliveryStatus {
+    PENDING = 'Pending',
+    IN_TRANSIT = 'In transit',
+    DELIVERED = 'Delivered',
+    ISSUES = 'Issues'
+}
+
+interface DropdownProps {
+    status: DeliveryStatus;
+    setStatus: React.Dispatch<React.SetStateAction<DeliveryStatus>>;
+}
+
+export default function Dropdown({ status, setStatus }: DropdownProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const [ bgClasses, setBgClasses ] = useState('')
+    const [ icon, setIcon ] = useState(<></>)
+
+    function handleOpenClick(event: React.MouseEvent<HTMLButtonElement>) {
+        event.preventDefault();
+        setIsOpen(!isOpen);
+    }
+
+    function getBgColor(status: DeliveryStatus) {
+        switch (status) {
+          case DeliveryStatus.PENDING:
+            return 'bg-yellow-500 hover:bg-yellow-400'
+          case DeliveryStatus.IN_TRANSIT:
+            return 'bg-blue-400 hover:bg-blue-300'
+          case DeliveryStatus.DELIVERED:
+            return 'bg-green-500 hover:bg-green-400'
+          case DeliveryStatus.ISSUES:
+            return 'bg-red-500 hover:bg-red-400'
+          default:
+            return 'bg-gray-400 hover:bg-gray-500'
+        }
+    }
+
+    function getIcon(status: DeliveryStatus) {
+        switch (status) {
+            case DeliveryStatus.PENDING:
+                return <Spinner size={18} />
+            case DeliveryStatus.IN_TRANSIT:
+                return <CarProfile size={18} />
+            case DeliveryStatus.DELIVERED:
+                return <Check size={18} />
+            case DeliveryStatus.ISSUES:
+                return <X size={18} />
+            default: 
+                return <></>
+        }
+    }
+
+    useEffect(() => {
+        setBgClasses(getBgColor(status))
+        setIcon(getIcon(status))
+    }, [status])
+
+    return (
+        <div className="relative w-64 w-full">
+            <button
+                onClick={handleOpenClick}
+                className={`flex justify-center items-center gap-3 w-[10rem] px-[1rem] ${bgClasses} rounded-lg text-gray-700 shadow-sm cursor-pointer transition-all duration-400`}
+            >
+                {icon}
+                {status}
+                <CaretDown size={16} />
+            </button>
+
+            { isOpen && (
+                <ul className="absolute w-full bg-gray-700 rounded-lg mt-1 shadow-lg border border-gray-500">
+                    {Object.values(DeliveryStatus).map((deliveryStatus: DeliveryStatus) => (
+                    <li
+                        key={deliveryStatus}
+                        onClick={() => {
+                            setStatus(deliveryStatus)
+                            setIsOpen(false);
+                        }}
+                        className={`flex justify-center items-center gap-3 px-[1rem] border-b border-gray-700 rounded-lg text-gray-700 ${getBgColor(deliveryStatus)} shadow-sm cursor-pointer transition-all duration-400`}
+                    >
+                        {(() => {
+                            switch (deliveryStatus) {
+                                case DeliveryStatus.PENDING:
+                                    return (
+                                        <Spinner size={18} />
+                                    )
+                                case DeliveryStatus.IN_TRANSIT:
+                                    return (
+                                        <CarProfile size={18} />
+                                    )
+                                case DeliveryStatus.DELIVERED:
+                                    return (
+                                        <Check size={18} />
+                                    )
+                                case DeliveryStatus.ISSUES:
+                                    return (
+                                        <X size={18} />
+                                    )
+                                default: 
+                                return null 
+                            }
+                        })()}
+                        {deliveryStatus}
+                    </li>
+                    ))}
+                </ul>
+                )
+            } 
+        </div>
+    )
+}

--- a/frontend/src/app/(private)/deliveries/[id]/page.tsx
+++ b/frontend/src/app/(private)/deliveries/[id]/page.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useParams } from "next/navigation"
+import Dropdown from "./components/dropdown"
+import { useState } from "react"
+
+enum DeliveryStatus {
+    PENDING = 'Pending',
+    IN_TRANSIT = 'In transit',
+    DELIVERED = 'Delivered',
+    ISSUES = 'Issues'
+}
+
+const delivery = {
+    id: '1',
+    origin: "New York (NY)",
+    destination: "Los Angeles (CA)",
+    status: DeliveryStatus.IN_TRANSIT,
+}
+
+const vehicle = {
+    id: '1',
+    model: "Volvo FH16",
+    type: "Truck",
+    plate: "ABC1234",
+    year: 2019
+}
+
+const driver = {
+    id: '1',
+    name: "John Doe",
+    license: "123",
+}
+
+export default function Page() {
+    const params = useParams()
+    
+    const id = String(params.id)
+
+    const deliveryStatus = delivery.status
+
+    const [ status, setStatus ] = useState(deliveryStatus)
+
+    return (
+        <div className="w-full px-[1rem]">
+            <div className="w-full flex items-center justify-center border-b border-gray-500 pb-[1rem]">
+                <h1 className="font-[600] text-[1.25rem] flex-1">{`From ${delivery.origin} to ${delivery.destination}`}</h1>
+                <div>
+                    <Dropdown status={status} setStatus={setStatus}/>
+                </div>
+                <span className="text-gray-200 flex-1 flex justify-end">{`#${id}`}</span>
+            </div>
+            <div className="flex gap-4 w-full h-full mt-[1rem]">
+                <div className="flex-1 border border-gray-500 rounded-lg p-[1rem]">
+                    <div>
+                        <span className="font-[500]">{driver.name}</span>
+                        <p className="text-[0.875rem] mt-[0.5rem] text-gray-200">License: {driver.license}</p>
+                    </div>
+                </div>
+                <div className="flex-1 border border-gray-500 rounded-lg p-[1rem]">
+                    <span className="font-[500]">{vehicle.model}</span>
+                    <p className="text-[0.875rem] mt-[0.5rem] text-gray-200">Plate: {vehicle.plate}</p>
+                    <p className="text-[0.875rem] mt-[0.5rem] text-gray-200">Type: {vehicle.type}</p>
+                    <p className="text-[0.875rem] mt-[0.5rem] text-gray-200">Year: {vehicle.year}</p>
+                </div>
+            </div> 
+        </div>
+    )
+}

--- a/frontend/src/app/(private)/deliveries/page.tsx
+++ b/frontend/src/app/(private)/deliveries/page.tsx
@@ -2,6 +2,7 @@
 
 import { CarProfile, Check, Plus, Spinner, X } from "@phosphor-icons/react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 enum DeliveryStatus {
     PENDING = 'Pending',
@@ -38,6 +39,12 @@ const deliveries = [
 ]
 
 export default function Page() {
+    const router = useRouter()
+
+    function handleRowClick(deliveryId: string) {
+        router.push(`/deliveries/${deliveryId}`)
+    }
+
     return (
         <div className="flex flex-col w-full items-center">
             <div className="flex justify-between w-full">
@@ -69,7 +76,11 @@ export default function Page() {
                     </thead>
                     <tbody>
                         {deliveries.map((row) => (
-                            <tr className="border-b border-gray-500 first:pl-6 last:pr-6" key={row.id}>
+                            <tr 
+                                className="border-b border-gray-500 first:pl-6 last:pr-6 cursor-pointer hover:bg-gray-500 transition-all duration-300" 
+                                key={row.id}
+                                onClick={ () => handleRowClick(row.id)}
+                            >
                                 <td className="p-2 first:pl-6 last:pr-6 w-[20%]">{row.id}</td>
                                 <td className="p-2">{row.from}</td>
                                 <td className="p-2">{row.to}</td>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14,11 +14,15 @@
 
   /* Primaries and secondaries */
   --color-blue-500: #3B82F6; /* main blue */
-  --color-blue-400: #60A5FA; /* hover */
+  --color-blue-400: #60A5FA; /* status/hover */
+  --color-blue-300: #8abcfa; /* hover */
   
-  --color-green-500: #10B981; /* success */
-  --color-yellow-500: #FBBF24; /* warning */
-  --color-red-500: #EF4444; /* error */
+  --color-green-500: #10B981; /* success/status */
+  --color-green-400: #3ee0aa; /* hover */
+  --color-yellow-500: #FBBF24; /* warning/status */
+  --color-yellow-400: #e0bf6a; /* hover */
+  --color-red-500: #EF4444; /* error/status */
+  --color-red-400: #f57575; /* hover */
 }
 
 @layer base {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -20,17 +20,21 @@ export default {
             800: 'var(--color-gray-800)',
           },
           blue: {
+            300: 'var(--color-blue-300)',
             400: 'var(--color-blue-400)',
             500: 'var(--color-blue-500)',
           },
           green: {
             500: 'var(--color-green-500)',
+            400: 'var(--color-green-400)',
           },
           yellow: {
             500: 'var(--color-yellow-500)',
+            400: 'var(--color-yellow-400)',
           },
           red: {
             500: 'var(--color-red-500)',
+            400: 'var(--color-red-400)'
           },
         },
       },


### PR DESCRIPTION
## Description

This PR implements the delivery details page, which displays delivery information along with associated driver and vehicle details. It also includes functionality to change the delivery status.

## Main changes

- Implemented `/deliveries/:id` page to display detailed delivery information
- Added status selection dropdown to allow updates
- Included driver and vehicle details on the delivery details page
- Made rows in the delivery list clickable, redirecting to the corresponding details page

## Motivation

These changes improve the usability of the delivery management flow by allowing users to:
- View detailed information about a delivery
- Check associated driver and vehicle
- Update the delivery status
- Navigate easily through the deliveries list via clickable rows 

## How to test

1. Access `/deliveries` or `/dashboard`
  - Click on a delivery row 
  - You should be redirected to `/deliveries/:id`
2. On the delivery details page:
  - Confirm that delivery, driver, and vehicle information are displayed
  - Try changing the delivery status and ensure the update is reflected

## Related issues

Closes #25 