### PR TITLE
feat: create domain use cases

### DIFF
--- a/backend/src/core/core/pagination-params.ts
+++ b/backend/src/core/core/pagination-params.ts
@@ -1,0 +1,3 @@
+export interface PaginationParams {
+  page: number
+}

--- a/backend/src/core/either.ts
+++ b/backend/src/core/either.ts
@@ -1,0 +1,43 @@
+// Error
+export class Left<L, R> {
+  readonly value: L
+
+  constructor(value: L) {
+    this.value = value
+  }
+
+  isRight(): this is Right<L, R> {
+    return false
+  }
+
+  isLeft(): this is Left<L, R> {
+    return true
+  }
+}
+
+// Success
+export class Right<L, R> {
+  readonly value: R
+
+  constructor(value: R) {
+    this.value = value
+  }
+
+  isRight(): this is Right<L, R> {
+    return true
+  }
+
+  isLeft(): this is Left<L, R> {
+    return false
+  }
+}
+
+export type Either<L, R> = Left<L, R> | Right<L, R>
+
+export const left = <L, R>(value: L): Either<L, R> => {
+  return new Left(value)
+}
+
+export const right = <L, R>(value: R): Either<L, R> => {
+  return new Right(value)
+}

--- a/backend/src/core/errors/errors/resource-already-exists-error.ts
+++ b/backend/src/core/errors/errors/resource-already-exists-error.ts
@@ -1,0 +1,7 @@
+import { UseCaseError } from '../use-case-error'
+
+export class ResourceAlreadyExistsError extends Error implements UseCaseError {
+  constructor() {
+    super('Resource already exists')
+  }
+}

--- a/backend/src/core/errors/errors/resource-not-found-error.ts
+++ b/backend/src/core/errors/errors/resource-not-found-error.ts
@@ -1,0 +1,7 @@
+import { UseCaseError } from '../use-case-error'
+
+export class ResourceNotFoundError extends Error implements UseCaseError {
+  constructor() {
+    super('Resource not found')
+  }
+}

--- a/backend/src/core/errors/use-case-error.ts
+++ b/backend/src/core/errors/use-case-error.ts
@@ -1,0 +1,3 @@
+export interface UseCaseError {
+  message: string
+}

--- a/backend/src/domain/application/mappers/delivery-status-mapper.ts
+++ b/backend/src/domain/application/mappers/delivery-status-mapper.ts
@@ -1,0 +1,15 @@
+import { DeliveryStatus } from '@/domain/enterprise/entities/delivery-status'
+
+export class DeliveryStatusMapper {
+  static toDomain(type: string): DeliveryStatus {
+    if (!Object.values(DeliveryStatus).includes(type as DeliveryStatus)) {
+      throw new Error(`Invalid delivery type: ${type}`)
+    }
+
+    return type as DeliveryStatus
+  }
+
+  static toExternal(type: DeliveryStatus): string {
+    return type
+  }
+}

--- a/backend/src/domain/application/mappers/vehicle-type-mapper.ts
+++ b/backend/src/domain/application/mappers/vehicle-type-mapper.ts
@@ -1,0 +1,15 @@
+import { VehicleType } from '@/domain/enterprise/entities/vehicle-type'
+
+export class VehicleTypeMapper {
+  static toDomain(type: string): VehicleType {
+    if (!Object.values(VehicleType).includes(type as VehicleType)) {
+      throw new Error(`Invalid vehicle type: ${type}`)
+    }
+
+    return type as VehicleType
+  }
+
+  static toExternal(type: VehicleType): string {
+    return type
+  }
+}

--- a/backend/src/domain/application/repositories/deliveries-repository.ts
+++ b/backend/src/domain/application/repositories/deliveries-repository.ts
@@ -1,0 +1,15 @@
+import { PaginationParams } from '@/core/core/pagination-params'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { DeliveryStatus } from '@/domain/enterprise/entities/delivery-status'
+
+export abstract class DeliveriesRepository {
+  abstract findById(id: string): Promise<Delivery | null>
+  abstract findByStatus(
+    status: DeliveryStatus,
+    params: PaginationParams,
+  ): Promise<Delivery[]>
+  abstract findAll(params: PaginationParams): Promise<Delivery[]>
+  abstract save(delivery: Delivery): Promise<void>
+  abstract create(delivery: Delivery): Promise<void>
+  abstract delete(id: string): Promise<void>
+}

--- a/backend/src/domain/application/repositories/drivers-repository.ts
+++ b/backend/src/domain/application/repositories/drivers-repository.ts
@@ -1,0 +1,11 @@
+import { PaginationParams } from '@/core/core/pagination-params'
+import { Driver } from '@/domain/enterprise/entities/driver'
+
+export abstract class DriversRepository {
+  abstract findById(id: string): Promise<Driver | null>
+  abstract findByLicense(license: string): Promise<Driver | null>
+  abstract findAll(params: PaginationParams): Promise<Driver[]>
+  abstract save(driver: Driver): Promise<void>
+  abstract create(driver: Driver): Promise<void>
+  abstract delete(id: string): Promise<void>
+}

--- a/backend/src/domain/application/repositories/vehicles-repository.ts
+++ b/backend/src/domain/application/repositories/vehicles-repository.ts
@@ -1,0 +1,11 @@
+import { PaginationParams } from '@/core/core/pagination-params'
+import { Vehicle } from '@/domain/enterprise/entities/vehicle'
+
+export abstract class VehiclesRepository {
+  abstract findById(id: string): Promise<Vehicle | null>
+  abstract findByPlate(plate: string): Promise<Vehicle | null>
+  abstract findAll(params: PaginationParams): Promise<Vehicle[]>
+  abstract save(vehicle: Vehicle): Promise<void>
+  abstract create(vehicle: Vehicle): Promise<void>
+  abstract delete(id: string): Promise<void>
+}

--- a/backend/src/domain/application/use-cases/deliveries/create-delivery.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/deliveries/create-delivery.use-case.spec.ts
@@ -1,0 +1,59 @@
+import { InMemoryDeliveriesRepository } from 'test/repositories/in-memory-deliveries-repository'
+import { CreateDeliveryUseCase } from './create-delivery.use-case'
+import { InMemoryDriversRepository } from 'test/repositories/in-memory-drivers-repository'
+import { makeDriver } from 'test/factories/make-driver'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { makeDelivery } from 'test/factories/make-delivery'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+let inMemoryDeliveriesRepository: InMemoryDeliveriesRepository
+let inMemoryDriversRepository: InMemoryDriversRepository
+let sut: CreateDeliveryUseCase
+
+describe('Create Delivery', () => {
+  beforeEach(() => {
+    inMemoryDeliveriesRepository = new InMemoryDeliveriesRepository()
+    inMemoryDriversRepository = new InMemoryDriversRepository()
+    sut = new CreateDeliveryUseCase(
+      inMemoryDeliveriesRepository,
+      inMemoryDriversRepository,
+    )
+  })
+
+  it('should be able to create a delivery', async () => {
+    const driver = makeDriver({}, new UniqueEntityId('driver-01'))
+
+    inMemoryDriversRepository.create(driver)
+
+    const delivery = {
+      driverId: 'driver-01',
+      origin: 'New York',
+      destination: 'Los Angeles',
+    }
+
+    const result = await sut.execute(delivery)
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryDeliveriesRepository.items).toHaveLength(1)
+    expect(result.value?.delivery.driverId.toString()).toEqual('driver-01')
+  })
+
+  it('should not be able to create a delivery with invalid driver', async () => {
+    inMemoryDeliveriesRepository.create(
+      makeDelivery({ driverId: new UniqueEntityId('driver-01') }),
+    )
+
+    const delivery = makeDelivery({
+      driverId: new UniqueEntityId('driver-02'),
+    })
+
+    const result = await sut.execute({
+      driverId: 'driver-02',
+      origin: delivery.origin,
+      destination: delivery.destination,
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(ResourceNotFoundError)
+  })
+})

--- a/backend/src/domain/application/use-cases/deliveries/create-delivery.use-case.ts
+++ b/backend/src/domain/application/use-cases/deliveries/create-delivery.use-case.ts
@@ -1,0 +1,50 @@
+import { Either, left, right } from '@/core/either'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { DeliveriesRepository } from '../../repositories/deliveries-repository'
+import { DriversRepository } from '../../repositories/drivers-repository'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+interface CreateDeliveryUseCaseRequest {
+  driverId: string
+  origin: string
+  destination: string
+}
+
+type CreateDeliveryUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    delivery: Delivery
+  }
+>
+
+export class CreateDeliveryUseCase {
+  constructor(
+    private deliveriesRepository: DeliveriesRepository,
+    private driversRepository: DriversRepository,
+  ) {}
+
+  async execute({
+    driverId,
+    origin,
+    destination,
+  }: CreateDeliveryUseCaseRequest): Promise<CreateDeliveryUseCaseResponse> {
+    const driver = await this.driversRepository.findById(driverId)
+
+    if (!driver) {
+      return left(new ResourceNotFoundError())
+    }
+
+    const delivery = Delivery.create({
+      driverId: new UniqueEntityId(driverId),
+      origin,
+      destination,
+    })
+
+    await this.deliveriesRepository.create(delivery)
+
+    return right({
+      delivery,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/deliveries/delete-delivery.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/deliveries/delete-delivery.use-case.spec.ts
@@ -1,0 +1,27 @@
+import { InMemoryDeliveriesRepository } from 'test/repositories/in-memory-deliveries-repository'
+import { makeDelivery } from 'test/factories/make-delivery'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { DeleteDeliveryUseCase } from './delete-delivery.use-case'
+
+let inMemoryDeliveriesRepository: InMemoryDeliveriesRepository
+let sut: DeleteDeliveryUseCase
+
+describe('Fetch Deliveries', () => {
+  beforeEach(() => {
+    inMemoryDeliveriesRepository = new InMemoryDeliveriesRepository()
+    sut = new DeleteDeliveryUseCase(inMemoryDeliveriesRepository)
+  })
+
+  it('should be able to delete a delivery', async () => {
+    const delivery = makeDelivery({}, new UniqueEntityId('delivery-01'))
+
+    inMemoryDeliveriesRepository.create(delivery)
+
+    const result = await sut.execute({
+      deliveryId: 'delivery-01',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryDeliveriesRepository.items).toHaveLength(0)
+  })
+})

--- a/backend/src/domain/application/use-cases/deliveries/delete-delivery.use-case.ts
+++ b/backend/src/domain/application/use-cases/deliveries/delete-delivery.use-case.ts
@@ -1,0 +1,35 @@
+import { Either, left, right } from '@/core/either'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { DeliveriesRepository } from '../../repositories/deliveries-repository'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+interface DeleteDeliveryUseCaseRequest {
+  deliveryId: string
+}
+
+type DeleteDeliveryUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    delivery: Delivery
+  }
+>
+
+export class DeleteDeliveryUseCase {
+  constructor(private deliveriesRepository: DeliveriesRepository) {}
+
+  async execute({
+    deliveryId,
+  }: DeleteDeliveryUseCaseRequest): Promise<DeleteDeliveryUseCaseResponse> {
+    const delivery = await this.deliveriesRepository.findById(deliveryId)
+
+    if (!delivery) {
+      return left(new ResourceNotFoundError())
+    }
+
+    await this.deliveriesRepository.delete(deliveryId)
+
+    return right({
+      delivery,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/deliveries/fetch-deliveries-by-status.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/deliveries/fetch-deliveries-by-status.use-case.spec.ts
@@ -1,0 +1,46 @@
+import { InMemoryDeliveriesRepository } from 'test/repositories/in-memory-deliveries-repository'
+import { makeDelivery } from 'test/factories/make-delivery'
+import { FetchDeliveriesByStatusUseCase } from './fetch-deliveries-by-status.use-case'
+import { DeliveryStatus } from '@/domain/enterprise/entities/delivery-status'
+
+let inMemoryDeliveriesRepository: InMemoryDeliveriesRepository
+let sut: FetchDeliveriesByStatusUseCase
+
+describe('Fetch Deliveries', () => {
+  beforeEach(() => {
+    inMemoryDeliveriesRepository = new InMemoryDeliveriesRepository()
+    sut = new FetchDeliveriesByStatusUseCase(inMemoryDeliveriesRepository)
+  })
+
+  it('should be able to fetch deliveries', async () => {
+    const delivery1 = makeDelivery({
+      status: DeliveryStatus.PENDING,
+    })
+    const delivery2 = makeDelivery({
+      status: DeliveryStatus.PENDING,
+    })
+
+    inMemoryDeliveriesRepository.create(delivery1)
+    inMemoryDeliveriesRepository.create(delivery2)
+
+    const result = await sut.execute({ status: 'PENDING', page: 1 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.deliveries).toHaveLength(2)
+  })
+
+  it('should be able to fetch paginated deliveries', async () => {
+    for (let i = 0; i < 12; i++) {
+      const delivery = makeDelivery({
+        status: DeliveryStatus.IN_TRANSIT,
+      })
+
+      inMemoryDeliveriesRepository.create(delivery)
+    }
+
+    const result = await sut.execute({ status: 'IN_TRANSIT', page: 2 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.deliveries).toHaveLength(2)
+  })
+})

--- a/backend/src/domain/application/use-cases/deliveries/fetch-deliveries-by-status.use-case.ts
+++ b/backend/src/domain/application/use-cases/deliveries/fetch-deliveries-by-status.use-case.ts
@@ -1,0 +1,36 @@
+import { Either, right } from '@/core/either'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { DeliveriesRepository } from '../../repositories/deliveries-repository'
+import { DeliveryStatusMapper } from '../../mappers/delivery-status-mapper'
+
+interface FetchDeliveriesByStatusUseCaseRequest {
+  status: string
+  page: number
+}
+
+type FetchDeliveriesByStatusUseCaseResponse = Either<
+  null,
+  {
+    deliveries: Delivery[]
+  }
+>
+
+export class FetchDeliveriesByStatusUseCase {
+  constructor(private deliveriesRepository: DeliveriesRepository) {}
+
+  async execute({
+    status,
+    page,
+  }: FetchDeliveriesByStatusUseCaseRequest): Promise<FetchDeliveriesByStatusUseCaseResponse> {
+    const domainStatus = DeliveryStatusMapper.toDomain(status)
+
+    const deliveries = await this.deliveriesRepository.findByStatus(
+      domainStatus,
+      { page },
+    )
+
+    return right({
+      deliveries,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/deliveries/fetch-last-deliveries.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/deliveries/fetch-last-deliveries.use-case.spec.ts
@@ -1,0 +1,39 @@
+import { InMemoryDeliveriesRepository } from 'test/repositories/in-memory-deliveries-repository'
+import { makeDelivery } from 'test/factories/make-delivery'
+import { FetchLastDeliveriesUseCase } from './fetch-last-deliveries.use-case'
+
+let inMemoryDeliveriesRepository: InMemoryDeliveriesRepository
+let sut: FetchLastDeliveriesUseCase
+
+describe('Fetch Deliveries', () => {
+  beforeEach(() => {
+    inMemoryDeliveriesRepository = new InMemoryDeliveriesRepository()
+    sut = new FetchLastDeliveriesUseCase(inMemoryDeliveriesRepository)
+  })
+
+  it('should be able to fetch deliveries', async () => {
+    const delivery1 = makeDelivery()
+    const delivery2 = makeDelivery()
+
+    inMemoryDeliveriesRepository.create(delivery1)
+    inMemoryDeliveriesRepository.create(delivery2)
+
+    const result = await sut.execute({ page: 1 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.deliveries).toHaveLength(2)
+  })
+
+  it('should be able to fetch paginated deliveries', async () => {
+    for (let i = 0; i < 12; i++) {
+      const delivery = makeDelivery()
+
+      inMemoryDeliveriesRepository.create(delivery)
+    }
+
+    const result = await sut.execute({ page: 2 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.deliveries).toHaveLength(2)
+  })
+})

--- a/backend/src/domain/application/use-cases/deliveries/fetch-last-deliveries.use-case.ts
+++ b/backend/src/domain/application/use-cases/deliveries/fetch-last-deliveries.use-case.ts
@@ -1,0 +1,28 @@
+import { Either, right } from '@/core/either'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { DeliveriesRepository } from '../../repositories/deliveries-repository'
+
+interface FetchLastDeliveriesUseCaseRequest {
+  page: number
+}
+
+type FetchLastDeliveriesUseCaseResponse = Either<
+  null,
+  {
+    deliveries: Delivery[]
+  }
+>
+
+export class FetchLastDeliveriesUseCase {
+  constructor(private deliveriesRepository: DeliveriesRepository) {}
+
+  async execute({
+    page,
+  }: FetchLastDeliveriesUseCaseRequest): Promise<FetchLastDeliveriesUseCaseResponse> {
+    const deliveries = await this.deliveriesRepository.findAll({ page })
+
+    return right({
+      deliveries,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/deliveries/get-delivery-by-id.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/deliveries/get-delivery-by-id.use-case.spec.ts
@@ -1,0 +1,27 @@
+import { InMemoryDeliveriesRepository } from 'test/repositories/in-memory-deliveries-repository'
+import { makeDelivery } from 'test/factories/make-delivery'
+import { GetDeliveryByIdUseCase } from './get-delivery-by-id.use-case'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+
+let inMemoryDeliveriesRepository: InMemoryDeliveriesRepository
+let sut: GetDeliveryByIdUseCase
+
+describe('Get Delivery by Id', () => {
+  beforeEach(() => {
+    inMemoryDeliveriesRepository = new InMemoryDeliveriesRepository()
+    sut = new GetDeliveryByIdUseCase(inMemoryDeliveriesRepository)
+  })
+
+  it('should be able to get a delivery by id', async () => {
+    const delivery = makeDelivery({}, new UniqueEntityId('delivery-01'))
+
+    inMemoryDeliveriesRepository.create(delivery)
+
+    const result = await sut.execute({
+      deliveryId: 'delivery-01',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.delivery.id.toString()).toEqual('delivery-01')
+  })
+})

--- a/backend/src/domain/application/use-cases/deliveries/get-delivery-by-id.use-case.ts
+++ b/backend/src/domain/application/use-cases/deliveries/get-delivery-by-id.use-case.ts
@@ -1,0 +1,33 @@
+import { Either, left, right } from '@/core/either'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { DeliveriesRepository } from '../../repositories/deliveries-repository'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+interface GetDeliveryByIdUseCaseRequest {
+  deliveryId: string
+}
+
+type GetDeliveryByIdUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    delivery: Delivery
+  }
+>
+
+export class GetDeliveryByIdUseCase {
+  constructor(private deliveriesRepository: DeliveriesRepository) {}
+
+  async execute({
+    deliveryId,
+  }: GetDeliveryByIdUseCaseRequest): Promise<GetDeliveryByIdUseCaseResponse> {
+    const delivery = await this.deliveriesRepository.findById(deliveryId)
+
+    if (!delivery) {
+      return left(new ResourceNotFoundError())
+    }
+
+    return right({
+      delivery,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/deliveries/update-delivery.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/deliveries/update-delivery.use-case.spec.ts
@@ -1,0 +1,34 @@
+import { InMemoryDeliveriesRepository } from 'test/repositories/in-memory-deliveries-repository'
+import { makeDelivery } from 'test/factories/make-delivery'
+import { UpdateDeliveryUseCase } from './update-delivery.use-case'
+import { DeliveryStatus } from '@/domain/enterprise/entities/delivery-status'
+
+let inMemoryDeliveriesRepository: InMemoryDeliveriesRepository
+let sut: UpdateDeliveryUseCase
+
+describe('Update Delivery', () => {
+  beforeEach(() => {
+    inMemoryDeliveriesRepository = new InMemoryDeliveriesRepository()
+    sut = new UpdateDeliveryUseCase(inMemoryDeliveriesRepository)
+  })
+
+  it('should be able to update a delivery', async () => {
+    const delivery = makeDelivery({
+      status: DeliveryStatus.PENDING,
+    })
+
+    inMemoryDeliveriesRepository.create(delivery)
+
+    delivery.status = DeliveryStatus.IN_TRANSIT
+
+    const result = await sut.execute({
+      deliveryId: delivery.id.toString(),
+      origin: delivery.origin,
+      destination: delivery.destination,
+      status: delivery.status,
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.delivery.status).toEqual(DeliveryStatus.IN_TRANSIT)
+  })
+})

--- a/backend/src/domain/application/use-cases/deliveries/update-delivery.use-case.ts
+++ b/backend/src/domain/application/use-cases/deliveries/update-delivery.use-case.ts
@@ -1,0 +1,48 @@
+import { Either, left, right } from '@/core/either'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { DeliveriesRepository } from '../../repositories/deliveries-repository'
+import { DeliveryStatusMapper } from '../../mappers/delivery-status-mapper'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+interface UpdateDeliveryUseCaseRequest {
+  deliveryId: string
+  origin: string
+  destination: string
+  status: string
+}
+
+type UpdateDeliveryUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    delivery: Delivery
+  }
+>
+
+export class UpdateDeliveryUseCase {
+  constructor(private deliveriesRepository: DeliveriesRepository) {}
+
+  async execute({
+    deliveryId,
+    origin,
+    destination,
+    status,
+  }: UpdateDeliveryUseCaseRequest): Promise<UpdateDeliveryUseCaseResponse> {
+    const delivery = await this.deliveriesRepository.findById(deliveryId)
+
+    if (!delivery) {
+      return left(new ResourceNotFoundError())
+    }
+
+    const domainStatus = DeliveryStatusMapper.toDomain(status)
+
+    delivery.origin = origin
+    delivery.destination = destination
+    delivery.status = domainStatus
+
+    await this.deliveriesRepository.save(delivery)
+
+    return right({
+      delivery,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/drivers/create-driver.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/drivers/create-driver.use-case.spec.ts
@@ -1,0 +1,42 @@
+import { InMemoryDriversRepository } from 'test/repositories/in-memory-drivers-repository'
+import { CreateDriverUseCase } from './create-driver.use-case'
+import { ResourceAlreadyExistsError } from '@/core/errors/errors/resource-already-exists-error'
+import { makeDriver } from 'test/factories/make-driver'
+
+let inMemoryDriversRepository: InMemoryDriversRepository
+let sut: CreateDriverUseCase
+
+describe('Create Driver', () => {
+  beforeEach(() => {
+    inMemoryDriversRepository = new InMemoryDriversRepository()
+    sut = new CreateDriverUseCase(inMemoryDriversRepository)
+  })
+
+  it('should be able to create a driver', async () => {
+    const driver = {
+      name: 'John Doe',
+      license: '1234567890',
+    }
+
+    const result = await sut.execute(driver)
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.driver.license).toEqual('1234567890')
+  })
+
+  it('should not be able to create a driver with same license', async () => {
+    inMemoryDriversRepository.create(makeDriver({ license: '1234567890' }))
+
+    const driver = makeDriver({
+      license: '1234567890',
+    })
+
+    const result = await sut.execute({
+      name: driver.name,
+      license: '1234567890',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(ResourceAlreadyExistsError)
+  })
+})

--- a/backend/src/domain/application/use-cases/drivers/create-driver.use-case.ts
+++ b/backend/src/domain/application/use-cases/drivers/create-driver.use-case.ts
@@ -1,0 +1,47 @@
+import { Either, left, right } from '@/core/either'
+import { Driver } from '@/domain/enterprise/entities/driver'
+import { DriversRepository } from '../../repositories/drivers-repository'
+import { ResourceAlreadyExistsError } from '@/core/errors/errors/resource-already-exists-error'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+
+interface CreateDriverUseCaseRequest {
+  vehicleId?: string
+  name: string
+  license: string
+}
+
+type CreateDriverUseCaseResponse = Either<
+  ResourceAlreadyExistsError,
+  {
+    driver: Driver
+  }
+>
+
+export class CreateDriverUseCase {
+  constructor(private driversRepository: DriversRepository) {}
+
+  async execute({
+    vehicleId,
+    name,
+    license,
+  }: CreateDriverUseCaseRequest): Promise<CreateDriverUseCaseResponse> {
+    const driverAlreadyExists =
+      await this.driversRepository.findByLicense(license)
+
+    if (driverAlreadyExists) {
+      return left(new ResourceAlreadyExistsError())
+    }
+
+    const driver = Driver.create({
+      vehicleId: vehicleId ? new UniqueEntityId(vehicleId) : null,
+      name,
+      license,
+    })
+
+    await this.driversRepository.create(driver)
+
+    return right({
+      driver,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/drivers/delete-driver.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/drivers/delete-driver.use-case.spec.ts
@@ -1,0 +1,27 @@
+import { InMemoryDriversRepository } from 'test/repositories/in-memory-drivers-repository'
+import { makeDriver } from 'test/factories/make-driver'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { DeleteDriverUseCase } from './delete-driver.use-case'
+
+let inMemoryDriversRepository: InMemoryDriversRepository
+let sut: DeleteDriverUseCase
+
+describe('Fetch Drivers', () => {
+  beforeEach(() => {
+    inMemoryDriversRepository = new InMemoryDriversRepository()
+    sut = new DeleteDriverUseCase(inMemoryDriversRepository)
+  })
+
+  it('should be able to delete a driver', async () => {
+    const driver = makeDriver({}, new UniqueEntityId('driver-01'))
+
+    inMemoryDriversRepository.create(driver)
+
+    const result = await sut.execute({
+      driverId: 'driver-01',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryDriversRepository.items).toHaveLength(0)
+  })
+})

--- a/backend/src/domain/application/use-cases/drivers/delete-driver.use-case.ts
+++ b/backend/src/domain/application/use-cases/drivers/delete-driver.use-case.ts
@@ -1,0 +1,35 @@
+import { Either, left, right } from '@/core/either'
+import { Driver } from '@/domain/enterprise/entities/driver'
+import { DriversRepository } from '../../repositories/drivers-repository'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+interface DeleteDriverUseCaseRequest {
+  driverId: string
+}
+
+type DeleteDriverUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    driver: Driver
+  }
+>
+
+export class DeleteDriverUseCase {
+  constructor(private driversRepository: DriversRepository) {}
+
+  async execute({
+    driverId,
+  }: DeleteDriverUseCaseRequest): Promise<DeleteDriverUseCaseResponse> {
+    const driver = await this.driversRepository.findById(driverId)
+
+    if (!driver) {
+      return left(new ResourceNotFoundError())
+    }
+
+    await this.driversRepository.delete(driverId)
+
+    return right({
+      driver,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/drivers/fetch-drivers.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/drivers/fetch-drivers.use-case.spec.ts
@@ -1,0 +1,39 @@
+import { InMemoryDriversRepository } from 'test/repositories/in-memory-drivers-repository'
+import { makeDriver } from 'test/factories/make-driver'
+import { FetchDriversUseCase } from './fetch-drivers.use-case'
+
+let inMemoryDriversRepository: InMemoryDriversRepository
+let sut: FetchDriversUseCase
+
+describe('Fetch Drivers', () => {
+  beforeEach(() => {
+    inMemoryDriversRepository = new InMemoryDriversRepository()
+    sut = new FetchDriversUseCase(inMemoryDriversRepository)
+  })
+
+  it('should be able to fetch drivers', async () => {
+    const driver1 = makeDriver()
+    const driver2 = makeDriver()
+
+    inMemoryDriversRepository.create(driver1)
+    inMemoryDriversRepository.create(driver2)
+
+    const result = await sut.execute({ page: 1 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.drivers).toHaveLength(2)
+  })
+
+  it('should be able to fetch paginated drivers', async () => {
+    for (let i = 0; i < 12; i++) {
+      const driver = makeDriver()
+
+      inMemoryDriversRepository.create(driver)
+    }
+
+    const result = await sut.execute({ page: 2 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.drivers).toHaveLength(2)
+  })
+})

--- a/backend/src/domain/application/use-cases/drivers/fetch-drivers.use-case.ts
+++ b/backend/src/domain/application/use-cases/drivers/fetch-drivers.use-case.ts
@@ -1,0 +1,28 @@
+import { Either, right } from '@/core/either'
+import { Driver } from '@/domain/enterprise/entities/driver'
+import { DriversRepository } from '../../repositories/drivers-repository'
+
+interface FetchDriversUseCaseRequest {
+  page: number
+}
+
+type FetchDriversUseCaseResponse = Either<
+  null,
+  {
+    drivers: Driver[]
+  }
+>
+
+export class FetchDriversUseCase {
+  constructor(private driversRepository: DriversRepository) {}
+
+  async execute({
+    page,
+  }: FetchDriversUseCaseRequest): Promise<FetchDriversUseCaseResponse> {
+    const drivers = await this.driversRepository.findAll({ page })
+
+    return right({
+      drivers,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/drivers/update-driver.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/drivers/update-driver.use-case.spec.ts
@@ -1,0 +1,35 @@
+import { InMemoryDriversRepository } from 'test/repositories/in-memory-drivers-repository'
+import { makeDriver } from 'test/factories/make-driver'
+import { UpdateDriverUseCase } from './update-driver.use-case'
+
+let inMemoryDriversRepository: InMemoryDriversRepository
+let sut: UpdateDriverUseCase
+
+describe('Update Driver', () => {
+  beforeEach(() => {
+    inMemoryDriversRepository = new InMemoryDriversRepository()
+    sut = new UpdateDriverUseCase(inMemoryDriversRepository)
+  })
+
+  it('should be able to update a driver', async () => {
+    const driver = makeDriver({
+      name: 'John Doe',
+      vehicleId: null,
+    })
+
+    inMemoryDriversRepository.create(driver)
+
+    const driverUpdated = {
+      driverId: driver.id.toString(),
+      name: 'John Smith Doe',
+      license: driver.license,
+      vehicleId: 'vehicle-id',
+    }
+
+    const result = await sut.execute(driverUpdated)
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.driver.name).toEqual('John Smith Doe')
+    expect(result.value?.driver.vehicleId.toString()).toEqual('vehicle-id')
+  })
+})

--- a/backend/src/domain/application/use-cases/drivers/update-driver.use-case.ts
+++ b/backend/src/domain/application/use-cases/drivers/update-driver.use-case.ts
@@ -1,0 +1,46 @@
+import { Either, left, right } from '@/core/either'
+import { Driver } from '@/domain/enterprise/entities/driver'
+import { DriversRepository } from '../../repositories/drivers-repository'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+
+interface UpdateDriverUseCaseRequest {
+  driverId: string
+  vehicleId?: string
+  name: string
+  license: string
+}
+
+type UpdateDriverUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    driver: Driver
+  }
+>
+
+export class UpdateDriverUseCase {
+  constructor(private driversRepository: DriversRepository) {}
+
+  async execute({
+    driverId,
+    vehicleId,
+    name,
+    license,
+  }: UpdateDriverUseCaseRequest): Promise<UpdateDriverUseCaseResponse> {
+    const driver = await this.driversRepository.findById(driverId)
+
+    if (!driver) {
+      return left(new ResourceNotFoundError())
+    }
+
+    driver.vehicleId = vehicleId ? new UniqueEntityId(vehicleId) : null
+    driver.name = name
+    driver.license = license
+
+    await this.driversRepository.save(driver)
+
+    return right({
+      driver,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/test.spec.ts
+++ b/backend/src/domain/application/use-cases/test.spec.ts
@@ -1,3 +1,0 @@
-test('Unit test - 1 plus 1', () => {
-  expect(1 + 1).toBe(2)
-})

--- a/backend/src/domain/application/use-cases/vehicles/create-vehicle.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/vehicles/create-vehicle.use-case.spec.ts
@@ -1,0 +1,41 @@
+import { InMemoryVehiclesRepository } from 'test/repositories/in-memory-vehicles-repository'
+import { CreateVehicleUseCase } from './create-vehicle.use-case'
+import { makeVehicle } from 'test/factories/make-vehicle'
+import { ResourceAlreadyExistsError } from '@/core/errors/errors/resource-already-exists-error'
+
+let inMemoryVehiclesRepository: InMemoryVehiclesRepository
+let sut: CreateVehicleUseCase
+
+describe('Create Vehicle', () => {
+  beforeEach(() => {
+    inMemoryVehiclesRepository = new InMemoryVehiclesRepository()
+    sut = new CreateVehicleUseCase(inMemoryVehiclesRepository)
+  })
+
+  it('should be able to create a vehicle', async () => {
+    const vehicle = {
+      plate: 'ABC1234',
+      model: 'Volvo FH',
+      type: 'TRUCK',
+      year: '2020',
+    }
+
+    const result = await sut.execute(vehicle)
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.vehicle.plate).toEqual(vehicle.plate)
+  })
+
+  it('should not be able to create a vehicle with same plate', async () => {
+    inMemoryVehiclesRepository.create(makeVehicle({ plate: 'ABC1234' }))
+
+    const vehicle = makeVehicle({
+      plate: 'ABC1234',
+    })
+
+    const result = await sut.execute(vehicle)
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(ResourceAlreadyExistsError)
+  })
+})

--- a/backend/src/domain/application/use-cases/vehicles/create-vehicle.use-case.ts
+++ b/backend/src/domain/application/use-cases/vehicles/create-vehicle.use-case.ts
@@ -1,0 +1,52 @@
+import { Either, left, right } from '@/core/either'
+import { Vehicle } from '@/domain/enterprise/entities/vehicle'
+import { VehiclesRepository } from '../../repositories/vehicles-repository'
+import { ResourceAlreadyExistsError } from '@/core/errors/errors/resource-already-exists-error'
+import { VehicleTypeMapper } from '../../mappers/vehicle-type-mapper'
+
+interface CreateVehicleUseCaseRequest {
+  plate: string
+  model: string
+  type: string
+  year: string
+}
+
+type CreateVehicleUseCaseResponse = Either<
+  ResourceAlreadyExistsError,
+  {
+    vehicle: Vehicle
+  }
+>
+
+export class CreateVehicleUseCase {
+  constructor(private vehiclesRepository: VehiclesRepository) {}
+
+  async execute({
+    plate,
+    model,
+    type,
+    year,
+  }: CreateVehicleUseCaseRequest): Promise<CreateVehicleUseCaseResponse> {
+    const vehicleAlreadyExists =
+      await this.vehiclesRepository.findByPlate(plate)
+
+    if (vehicleAlreadyExists) {
+      return left(new ResourceAlreadyExistsError())
+    }
+
+    const domainType = VehicleTypeMapper.toDomain(type)
+
+    const vehicle = Vehicle.create({
+      plate,
+      model,
+      type: domainType,
+      year,
+    })
+
+    await this.vehiclesRepository.create(vehicle)
+
+    return right({
+      vehicle,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/vehicles/delete-vehicle.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/vehicles/delete-vehicle.use-case.spec.ts
@@ -1,0 +1,27 @@
+import { InMemoryVehiclesRepository } from 'test/repositories/in-memory-vehicles-repository'
+import { makeVehicle } from 'test/factories/make-vehicle'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { DeleteVehicleUseCase } from './delete-vehicle.use-case'
+
+let inMemoryVehiclesRepository: InMemoryVehiclesRepository
+let sut: DeleteVehicleUseCase
+
+describe('Fetch Vehicles', () => {
+  beforeEach(() => {
+    inMemoryVehiclesRepository = new InMemoryVehiclesRepository()
+    sut = new DeleteVehicleUseCase(inMemoryVehiclesRepository)
+  })
+
+  it('should be able to delete a vehicle', async () => {
+    const vehicle = makeVehicle({}, new UniqueEntityId('vehicle-01'))
+
+    inMemoryVehiclesRepository.create(vehicle)
+
+    const result = await sut.execute({
+      vehicleId: 'vehicle-01',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryVehiclesRepository.items).toHaveLength(0)
+  })
+})

--- a/backend/src/domain/application/use-cases/vehicles/delete-vehicle.use-case.ts
+++ b/backend/src/domain/application/use-cases/vehicles/delete-vehicle.use-case.ts
@@ -1,0 +1,35 @@
+import { Either, left, right } from '@/core/either'
+import { Vehicle } from '@/domain/enterprise/entities/vehicle'
+import { VehiclesRepository } from '../../repositories/vehicles-repository'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+interface DeleteVehicleUseCaseRequest {
+  vehicleId: string
+}
+
+type DeleteVehicleUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    vehicle: Vehicle
+  }
+>
+
+export class DeleteVehicleUseCase {
+  constructor(private vehiclesRepository: VehiclesRepository) {}
+
+  async execute({
+    vehicleId,
+  }: DeleteVehicleUseCaseRequest): Promise<DeleteVehicleUseCaseResponse> {
+    const vehicle = await this.vehiclesRepository.findById(vehicleId)
+
+    if (!vehicle) {
+      return left(new ResourceNotFoundError())
+    }
+
+    await this.vehiclesRepository.delete(vehicleId)
+
+    return right({
+      vehicle,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/vehicles/fetch-vehicles.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/vehicles/fetch-vehicles.use-case.spec.ts
@@ -1,0 +1,39 @@
+import { InMemoryVehiclesRepository } from 'test/repositories/in-memory-vehicles-repository'
+import { makeVehicle } from 'test/factories/make-vehicle'
+import { FetchVehiclesUseCase } from './fetch-vehicles.use-case'
+
+let inMemoryVehiclesRepository: InMemoryVehiclesRepository
+let sut: FetchVehiclesUseCase
+
+describe('Fetch Vehicles', () => {
+  beforeEach(() => {
+    inMemoryVehiclesRepository = new InMemoryVehiclesRepository()
+    sut = new FetchVehiclesUseCase(inMemoryVehiclesRepository)
+  })
+
+  it('should be able to fetch vehicles', async () => {
+    const vehicle1 = makeVehicle()
+    const vehicle2 = makeVehicle()
+
+    inMemoryVehiclesRepository.create(vehicle1)
+    inMemoryVehiclesRepository.create(vehicle2)
+
+    const result = await sut.execute({ page: 1 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.vehicles).toHaveLength(2)
+  })
+
+  it('should be able to fetch paginated vehicles', async () => {
+    for (let i = 0; i < 12; i++) {
+      const vehicle = makeVehicle()
+
+      inMemoryVehiclesRepository.create(vehicle)
+    }
+
+    const result = await sut.execute({ page: 2 })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.vehicles).toHaveLength(2)
+  })
+})

--- a/backend/src/domain/application/use-cases/vehicles/fetch-vehicles.use-case.ts
+++ b/backend/src/domain/application/use-cases/vehicles/fetch-vehicles.use-case.ts
@@ -1,0 +1,28 @@
+import { Either, right } from '@/core/either'
+import { Vehicle } from '@/domain/enterprise/entities/vehicle'
+import { VehiclesRepository } from '../../repositories/vehicles-repository'
+
+interface FetchVehiclesUseCaseRequest {
+  page: number
+}
+
+type FetchVehiclesUseCaseResponse = Either<
+  null,
+  {
+    vehicles: Vehicle[]
+  }
+>
+
+export class FetchVehiclesUseCase {
+  constructor(private vehiclesRepository: VehiclesRepository) {}
+
+  async execute({
+    page,
+  }: FetchVehiclesUseCaseRequest): Promise<FetchVehiclesUseCaseResponse> {
+    const vehicles = await this.vehiclesRepository.findAll({ page })
+
+    return right({
+      vehicles,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/vehicles/update-vehicle.use-case.spec.ts
+++ b/backend/src/domain/application/use-cases/vehicles/update-vehicle.use-case.spec.ts
@@ -1,0 +1,34 @@
+import { InMemoryVehiclesRepository } from 'test/repositories/in-memory-vehicles-repository'
+import { makeVehicle } from 'test/factories/make-vehicle'
+import { UpdateVehicleUseCase } from './update-vehicle.use-case'
+
+let inMemoryVehiclesRepository: InMemoryVehiclesRepository
+let sut: UpdateVehicleUseCase
+
+describe('Update Vehicle', () => {
+  beforeEach(() => {
+    inMemoryVehiclesRepository = new InMemoryVehiclesRepository()
+    sut = new UpdateVehicleUseCase(inMemoryVehiclesRepository)
+  })
+
+  it('should be able to update a vehicle', async () => {
+    const vehicle = makeVehicle({
+      model: 'Volvo FH',
+    })
+
+    inMemoryVehiclesRepository.create(vehicle)
+
+    vehicle.model = 'Volvo FH 540'
+
+    const result = await sut.execute({
+      vehicleId: vehicle.id.toString(),
+      plate: vehicle.plate,
+      model: vehicle.model,
+      type: vehicle.type,
+      year: vehicle.year,
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.vehicle.model).toEqual('Volvo FH 540')
+  })
+})

--- a/backend/src/domain/application/use-cases/vehicles/update-vehicle.use-case.ts
+++ b/backend/src/domain/application/use-cases/vehicles/update-vehicle.use-case.ts
@@ -1,0 +1,54 @@
+import { Either, left, right } from '@/core/either'
+import { Vehicle } from '@/domain/enterprise/entities/vehicle'
+import { VehiclesRepository } from '../../repositories/vehicles-repository'
+import { VehicleTypeMapper } from '../../mappers/vehicle-type-mapper'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+
+interface UpdateVehicleUseCaseRequest {
+  vehicleId: string
+  driverId?: string | null
+  plate: string
+  model: string
+  type: string
+  year: string
+}
+
+type UpdateVehicleUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    vehicle: Vehicle
+  }
+>
+
+export class UpdateVehicleUseCase {
+  constructor(private vehiclesRepository: VehiclesRepository) {}
+
+  async execute({
+    vehicleId,
+    driverId,
+    plate,
+    model,
+    type,
+    year,
+  }: UpdateVehicleUseCaseRequest): Promise<UpdateVehicleUseCaseResponse> {
+    const vehicle = await this.vehiclesRepository.findById(vehicleId)
+
+    if (!vehicle) {
+      return left(new ResourceNotFoundError())
+    }
+
+    const domainType = VehicleTypeMapper.toDomain(type)
+
+    vehicle.plate = plate
+    vehicle.model = model
+    vehicle.type = domainType
+    vehicle.year = year
+    vehicle.driverId = driverId ?? null
+
+    await this.vehiclesRepository.save(vehicle)
+
+    return right({
+      vehicle,
+    })
+  }
+}

--- a/backend/src/domain/application/use-cases/vehicles/update-vehicle.use-case.ts
+++ b/backend/src/domain/application/use-cases/vehicles/update-vehicle.use-case.ts
@@ -3,6 +3,7 @@ import { Vehicle } from '@/domain/enterprise/entities/vehicle'
 import { VehiclesRepository } from '../../repositories/vehicles-repository'
 import { VehicleTypeMapper } from '../../mappers/vehicle-type-mapper'
 import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
 
 interface UpdateVehicleUseCaseRequest {
   vehicleId: string
@@ -43,7 +44,7 @@ export class UpdateVehicleUseCase {
     vehicle.model = model
     vehicle.type = domainType
     vehicle.year = year
-    vehicle.driverId = driverId ?? null
+    vehicle.driverId = driverId ? new UniqueEntityId(driverId) : null
 
     await this.vehiclesRepository.save(vehicle)
 

--- a/backend/src/domain/enterprise/entities/delivery.ts
+++ b/backend/src/domain/enterprise/entities/delivery.ts
@@ -3,8 +3,8 @@ import { UniqueEntityId } from '@/core/entities/unique-entity-id'
 import { Optional } from '@/core/types/optional'
 import { DeliveryStatus } from './delivery-status'
 
-interface DeliveryProps {
-  driverId: string
+export interface DeliveryProps {
+  driverId: UniqueEntityId
   origin: string
   destination: string
   status: DeliveryStatus
@@ -12,12 +12,8 @@ interface DeliveryProps {
   updatedAt?: Date | null
 }
 
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-
 export class Delivery extends Entity<DeliveryProps> {
-  get driverId(): string {
+  get driverId(): UniqueEntityId {
     return this.props.driverId
   }
 
@@ -45,18 +41,29 @@ export class Delivery extends Entity<DeliveryProps> {
     this.props.updatedAt = new Date()
   }
 
+  set origin(origin: string) {
+    this.props.origin = origin
+    this.touch()
+  }
+
+  set destination(destination: string) {
+    this.props.destination = destination
+    this.touch()
+  }
+
   set status(status: DeliveryStatus) {
     this.props.status = status
     this.touch()
   }
 
   static create(
-    props: Optional<DeliveryProps, 'createdAt'>,
+    props: Optional<DeliveryProps, 'status' | 'createdAt'>,
     id?: UniqueEntityId,
   ) {
     const delivery = new Delivery(
       {
         ...props,
+        status: props.status ?? DeliveryStatus.PENDING,
         createdAt: props.createdAt ?? new Date(),
       },
       id,

--- a/backend/src/domain/enterprise/entities/driver.ts
+++ b/backend/src/domain/enterprise/entities/driver.ts
@@ -1,18 +1,15 @@
 import { Entity } from '@/core/entities/entity'
 import { UniqueEntityId } from '@/core/entities/unique-entity-id'
 
-interface DriverProps {
-  vehicleId: string
+export interface DriverProps {
+  vehicleId?: UniqueEntityId | null
   name: string
   license: string
 }
 
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-
 export class Driver extends Entity<DriverProps> {
-  get vehicleId(): string {
-    return this.props.vehicleId
+  get vehicleId(): UniqueEntityId | null {
+    return this.props.vehicleId ?? null
   }
 
   get name(): string {
@@ -21,6 +18,18 @@ export class Driver extends Entity<DriverProps> {
 
   get license(): string {
     return this.props.license
+  }
+
+  set vehicleId(vehicleId: UniqueEntityId | null) {
+    this.props.vehicleId = vehicleId
+  }
+
+  set name(name: string) {
+    this.props.name = name
+  }
+
+  set license(license: string) {
+    this.props.license = license
   }
 
   static create(props: DriverProps, id?: UniqueEntityId) {

--- a/backend/src/domain/enterprise/entities/vehicle.ts
+++ b/backend/src/domain/enterprise/entities/vehicle.ts
@@ -3,7 +3,7 @@ import { VehicleType } from './vehicle-type'
 import { UniqueEntityId } from '@/core/entities/unique-entity-id'
 
 export interface VehicleProps {
-  driverId?: string | null
+  driverId?: UniqueEntityId | null
   plate: string
   model: string
   type: VehicleType
@@ -11,7 +11,7 @@ export interface VehicleProps {
 }
 
 export class Vehicle extends Entity<VehicleProps> {
-  get driverId(): string | null {
+  get driverId(): UniqueEntityId | null {
     return this.props.driverId ?? null
   }
 
@@ -47,7 +47,7 @@ export class Vehicle extends Entity<VehicleProps> {
     this.props.year = year
   }
 
-  set driverId(driverId: string | null) {
+  set driverId(driverId: UniqueEntityId | null) {
     this.props.driverId = driverId
   }
 

--- a/backend/src/domain/enterprise/entities/vehicle.ts
+++ b/backend/src/domain/enterprise/entities/vehicle.ts
@@ -31,6 +31,26 @@ export class Vehicle extends Entity<VehicleProps> {
     return this.props.year
   }
 
+  set plate(plate: string) {
+    this.props.plate = plate
+  }
+
+  set model(model: string) {
+    this.props.model = model
+  }
+
+  set type(type: VehicleType) {
+    this.props.type = type
+  }
+
+  set year(year: string) {
+    this.props.year = year
+  }
+
+  set driverId(driverId: string | null) {
+    this.props.driverId = driverId
+  }
+
   static create(props: VehicleProps, id?: UniqueEntityId) {
     const vehicle = new Vehicle(props, id)
 

--- a/backend/src/domain/enterprise/entities/vehicle.ts
+++ b/backend/src/domain/enterprise/entities/vehicle.ts
@@ -2,16 +2,13 @@ import { Entity } from '@/core/entities/entity'
 import { VehicleType } from './vehicle-type'
 import { UniqueEntityId } from '@/core/entities/unique-entity-id'
 
-interface VehicleProps {
+export interface VehicleProps {
   driverId?: string | null
   plate: string
   model: string
   type: VehicleType
   year: string
 }
-
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 export class Vehicle extends Entity<VehicleProps> {
   get driverId(): string | null {

--- a/backend/test/factories/make-delivery.ts
+++ b/backend/test/factories/make-delivery.ts
@@ -1,0 +1,22 @@
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { Delivery, DeliveryProps } from '@/domain/enterprise/entities/delivery'
+import { DeliveryStatus } from '@/domain/enterprise/entities/delivery-status'
+import { faker } from '@faker-js/faker'
+
+export function makeDelivery(
+  override: Partial<DeliveryProps> = {},
+  id?: UniqueEntityId,
+) {
+  const delivery = Delivery.create(
+    {
+      driverId: new UniqueEntityId(),
+      origin: faker.location.city(),
+      destination: faker.location.city(),
+      status: DeliveryStatus.PENDING,
+      ...override,
+    },
+    id,
+  )
+
+  return delivery
+}

--- a/backend/test/factories/make-driver.ts
+++ b/backend/test/factories/make-driver.ts
@@ -1,0 +1,20 @@
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { Driver, DriverProps } from '@/domain/enterprise/entities/driver'
+import { faker } from '@faker-js/faker'
+
+export function makeDriver(
+  override: Partial<DriverProps> = {},
+  id?: UniqueEntityId,
+) {
+  const driver = Driver.create(
+    {
+      vehicleId: new UniqueEntityId(),
+      name: faker.person.fullName(),
+      license: faker.string.numeric(10),
+      ...override,
+    },
+    id,
+  )
+
+  return driver
+}

--- a/backend/test/factories/make-vehicle.ts
+++ b/backend/test/factories/make-vehicle.ts
@@ -1,0 +1,22 @@
+import { UniqueEntityId } from '@/core/entities/unique-entity-id'
+import { Vehicle, VehicleProps } from '@/domain/enterprise/entities/vehicle'
+import { VehicleType } from '@/domain/enterprise/entities/vehicle-type'
+import { faker } from '@faker-js/faker'
+
+export function makeVehicle(
+  override: Partial<VehicleProps> = {},
+  id?: UniqueEntityId,
+) {
+  const vehicle = Vehicle.create(
+    {
+      plate: faker.vehicle.vrm(),
+      model: faker.vehicle.model(),
+      type: VehicleType.TRUCK,
+      year: String(faker.date.past().getFullYear()),
+      ...override,
+    },
+    id,
+  )
+
+  return vehicle
+}

--- a/backend/test/repositories/in-memory-deliveries-repository.ts
+++ b/backend/test/repositories/in-memory-deliveries-repository.ts
@@ -1,0 +1,59 @@
+import { PaginationParams } from '@/core/core/pagination-params'
+import { DeliveriesRepository } from '@/domain/application/repositories/deliveries-repository'
+import { Delivery } from '@/domain/enterprise/entities/delivery'
+import { DeliveryStatus } from '@/domain/enterprise/entities/delivery-status'
+
+export class InMemoryDeliveriesRepository implements DeliveriesRepository {
+  public items: Delivery[] = []
+
+  async findById(id: string) {
+    const delivery = this.items.find((item) => item.id.toString() === id)
+
+    if (!delivery) {
+      return null
+    }
+
+    return delivery
+  }
+
+  async findByStatus(status: DeliveryStatus, { page }: PaginationParams) {
+    const deliveriesFiltered = this.items.filter(
+      (item) => item.status === status,
+    )
+
+    const deliveries = deliveriesFiltered.slice((page - 1) * 10, page * 10)
+
+    return deliveries
+  }
+
+  async findAll({ page }: PaginationParams) {
+    const deliveries = this.items
+      .slice((page - 1) * 10, page * 10)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      )
+
+    return deliveries
+  }
+
+  async save(delivery: Delivery) {
+    const deliveryIndex = this.items.findIndex((item) => delivery.equals(item))
+
+    this.items[deliveryIndex] = delivery
+  }
+
+  async create(delivery: Delivery) {
+    this.items.push(delivery)
+  }
+
+  async delete(id: string) {
+    const deliveryIndex = this.items.findIndex(
+      (item) => item.id.toString() === id,
+    )
+
+    if (deliveryIndex !== -1) {
+      this.items.splice(deliveryIndex, 1)
+    }
+  }
+}

--- a/backend/test/repositories/in-memory-drivers-repository.ts
+++ b/backend/test/repositories/in-memory-drivers-repository.ts
@@ -1,0 +1,53 @@
+import { PaginationParams } from '@/core/core/pagination-params'
+import { DriversRepository } from '@/domain/application/repositories/drivers-repository'
+import { Driver } from '@/domain/enterprise/entities/driver'
+
+export class InMemoryDriversRepository implements DriversRepository {
+  public items: Driver[] = []
+
+  async findById(id: string) {
+    const driver = this.items.find((item) => item.id.toString() === id)
+
+    if (!driver) {
+      return null
+    }
+
+    return driver
+  }
+
+  async findByLicense(license: string) {
+    const driver = this.items.find((item) => item.license === license)
+
+    if (!driver) {
+      return null
+    }
+
+    return driver
+  }
+
+  async findAll({ page }: PaginationParams) {
+    const drivers = this.items.slice((page - 1) * 10, page * 10)
+
+    return drivers
+  }
+
+  async save(driver: Driver) {
+    const driverIndex = this.items.findIndex((item) => driver.equals(item))
+
+    this.items[driverIndex] = driver
+  }
+
+  async create(driver: Driver) {
+    this.items.push(driver)
+  }
+
+  async delete(id: string) {
+    const driverIndex = this.items.findIndex(
+      (item) => item.id.toString() === id,
+    )
+
+    if (driverIndex !== -1) {
+      this.items.splice(driverIndex, 1)
+    }
+  }
+}

--- a/backend/test/repositories/in-memory-vehicles-repository.ts
+++ b/backend/test/repositories/in-memory-vehicles-repository.ts
@@ -1,0 +1,53 @@
+import { PaginationParams } from '@/core/core/pagination-params'
+import { VehiclesRepository } from '@/domain/application/repositories/vehicles-repository'
+import { Vehicle } from '@/domain/enterprise/entities/vehicle'
+
+export class InMemoryVehiclesRepository implements VehiclesRepository {
+  public items: Vehicle[] = []
+
+  async findById(id: string) {
+    const vehicle = this.items.find((item) => item.id.toString() === id)
+
+    if (!vehicle) {
+      return null
+    }
+
+    return vehicle
+  }
+
+  async findByPlate(plate: string) {
+    const vehicle = this.items.find((item) => item.plate === plate)
+
+    if (!vehicle) {
+      return null
+    }
+
+    return vehicle
+  }
+
+  async findAll({ page }: PaginationParams) {
+    const vehicles = this.items.slice((page - 1) * 10, page * 10)
+
+    return vehicles
+  }
+
+  async save(vehicle: Vehicle) {
+    const vehicleIndex = this.items.findIndex((item) => vehicle.equals(item))
+
+    this.items[vehicleIndex] = vehicle
+  }
+
+  async create(vehicle: Vehicle) {
+    this.items.push(vehicle)
+  }
+
+  async delete(id: string) {
+    const vehicleIndex = this.items.findIndex(
+      (item) => item.id.toString() === id,
+    )
+
+    if (vehicleIndex !== -1) {
+      this.items.splice(vehicleIndex, 1)
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR implements domain use cases for Vehicles, Drivers, and Deliveries in the application layer.

## Main changes

- Implemented use cases for `Deliveries`, `Drivers`, and `Vehicles` (CRUD operations)
- Updated entities to ensure compatibility with use cases
- Created repository interfaces for `Deliveries`, `Drivers`, and `Vehicles` 
- Added unit tests for all use cases

## Motivation

This implementation establishes the domain application layer by introducing business logic through use cases. It also prepares a solid foundation for implementing the infrastructure layer.

## How to test

1. Go to the `/backend` directory:
  - Run `pnpm run test` to execute all unit tests
  - Confirm that all tests pass successfully

## Related issues

Closes #39 